### PR TITLE
[#95612064] Allow listen addresses and port to be configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,7 @@
 # defaults file for hipach
 
 redis_port: 6379
+
+hipache_listen_port: 80
+hipache_listen_address:
+hipache_listen_address6:

--- a/templates/hipache.conf.j2
+++ b/templates/hipache.conf.j2
@@ -2,10 +2,15 @@
     "server": {
         "debug": true,
         "accessLog": "/var/log/hipache/access.log",
+{% if hipache_listen_address %}
+        "address": ["{{ hipache_listen_address }}"],
+{% endif %}
 {% if ansible_all_ipv6_addresses == [] %}
         "address6": [],
+{% elif hipache_listen_address6 %}
+        "address6": ["{{ hipache_listen_address6 }}"],
 {% endif %}
-        "port": 80,
+        "port": {{ hipache_listen_port }},
         "workers": 5,
         "maxSockets": 100,
         "deadBackendTTL": 30,


### PR DESCRIPTION
Expose them as variables so that we can put Hipache on a different address
and port. Such as `localhost:8080`, to be frontend by Nginx.
