### PR TITLE
[#98748824] Pin node-hipache version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Role Variables
 
 `redis_port` port that the redis instance listens on.
 
+`node_hipache_version` version of node-hipache that is to be installed. Defaults to `latest`
+
 Dependencies
 ------------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+MEMORY_DEFAULT = 512
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = "hipache"
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = MEMORY_DEFAULT
+  end
+
+  config.vm.provider :vmware_fusion do |v|
+    v.vmx["memsize"] = MEMORY_DEFAULT
+  end
+
+  config.vm.provision :shell, inline: "apt-get purge -qq -y --auto-remove chef puppet"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "site.yml"
+  end
+end

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  sudo: yes
+  vars:
+    - redis_host: localhost
+  roles:
+    - .

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   with_items:
     - python-software-properties
     - nodejs
-    - node-hipache
+    - "{% if node_hipache_version is defined %}node-hipache={{ node_hipache_version }}{% else %}node-hipache{% endif %}"
 
 - name: copy hipache upstart script
   copy: src=hipache.upstart dest=/etc/init/hipache.conf owner=root group=root mode=0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,10 @@
 
 - name: Install Hipache packages.
   apt: update_cache=true name="{{ item }}"
-  with_items: packages
+  with_items:
+    - python-software-properties
+    - nodejs
+    - node-hipache
 
 - name: copy hipache upstart script
   copy: src=hipache.upstart dest=/etc/init/hipache.conf owner=root group=root mode=0644

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,2 @@
 ---
 # vars file for hipach
-
-packages:
-  - python-software-properties
-  - nodejs
-  - node-hipache


### PR DESCRIPTION
[Pin the versions of components that we use](https://www.pivotaltracker.com/story/show/98748824)

**What**

To prevent breaking changes of components (e.g. Tsuru API, MongoDB, etc) causing the platform to break we should pin or build to a particular version, this will ensure a consistent build.

This PR adds version control for [hipache](https://github.com/hipache/hipache)

**How to review this PR**

This PR has been written to be reviewed in the following context:
- I want to create a vagrant environment to help me develop and test locally
- I want to parameterise one of the packages so I would like to move them into the `task/main.yml` file so they are easier to find and modify
- I want to specifically allow the `hipache`  to be pinned to a specific version
- I want to update the documentation so others know how to pin a specific version of `hipache`

**How to test this PR**

A vagrant box has been provided for testing.

```
$ vagrant up
```

You can supply the following snippet to the `site.yml` for testing version pinning:

```
vars:
  - node_hipache_version: 0.2.5-6~trusty1
```

**Who should review this PR**
- Any one in the world, man, woman, child or badger!
